### PR TITLE
Table decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-embedded-hal = { version = "0.2.4", features = ["unproven"] }
-either = { version = "1.6.1", default-features = false }
+embedded-hal = { version = "0.2", features = ["unproven"] }
+either = { version = "1.6", default-features = false }
 
 [dev-dependencies]
-version-sync = "0.9.1"
-cortex-m = "0.6.3"
-cortex-m-rt = "0.6.13"
-panic-semihosting = "0.5.3"
+version-sync = "0.9"
+cortex-m = "0.6"
+cortex-m-rt = "0.6"
+panic-semihosting = "0.5"
+cortex-m-semihosting = "0.3"
 
 [dev-dependencies.stm32f3xx-hal]
 version = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = { version = "0.2.4", features = ["unproven"] }
 either = { version = "1.6.1", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-either = { version = "1.5.3", default-features = false }
+either = { version = "1.6.1", default-features = false }
 
 [dev-dependencies]
-version-sync = "0.8"
-cortex-m = "0.6.2"
-cortex-m-rt = "0.6.12"
+version-sync = "0.9.1"
+cortex-m = "0.6.3"
+cortex-m-rt = "0.6.13"
 panic-semihosting = "0.5.3"
 
 [dev-dependencies.stm32f3xx-hal]
-version = "0.4.1"
+version = "0.5.0"
 features = [ "rt", "stm32f303" ]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ either = { version = "1.5.3", default-features = false }
 
 [dev-dependencies]
 version-sync = "0.8"
-cortex-m = "0.6.1"
-cortex-m-rt = "0.6.10"
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
 panic-semihosting = "0.5.3"
 
 [dev-dependencies.stm32f3xx-hal]
-version = "0.3.0"
+version = "0.4.1"
 features = [ "rt", "stm32f303" ]
+
+[features]
+default = []
+table-decoder = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,11 @@ pub struct Rotary<A, B> {
     pin_a: A,
     pin_b: B,
     state: u8,
+
+    #[cfg(feature = "table-decoder")]
+    prev_next: u8,
+    #[cfg(feature = "table-decoder")]
+    store: u16,
 }
 
 /// The encoder direction is either `Clockwise`, `CounterClockwise`, or `None`
@@ -34,6 +39,7 @@ pub enum Direction {
     None,
 }
 
+#[cfg(not(feature = "table-decoder"))]
 impl From<u8> for Direction {
     fn from(s: u8) -> Self {
         match s {
@@ -56,6 +62,11 @@ where
             pin_a,
             pin_b,
             state: 0u8,
+
+            #[cfg(feature = "table-decoder")]
+            prev_next: 0u8,
+            #[cfg(feature = "table-decoder")]
+            store: 0u16,
         }
     }
 
@@ -78,6 +89,35 @@ where
 
 
     #[cfg(feature = "table-decoder")]
+    /// Call `update` to evaluate the next state of the encoder, propagates errors from `InputPin` read
     pub fn update(&mut self) -> Result<Direction, Either<A::Error, B::Error>> {
+        // Implemented after https://www.best-microcontroller-projects.com/rotary-encoder.html
+        self.prev_next <<= 2;
+        if self.pin_a.is_high().map_err(Either::Left)? {
+            self.prev_next |= 0x02;
+        }
+        if self.pin_b.is_high().map_err(Either::Right)? {
+            self.prev_next |= 0x01;
+        }
+        self.prev_next &= 0x0f;
+
+        match self.prev_next {
+           /*Invalid cases 0 | 3 | 5 | 6 | 9 | 10 | 12 | 15=>, */
+           /*valid cases*/ 1 | 2 | 4 | 7 | 8 | 11 | 13 | 14 => {
+               self.store <<= 4;
+               self.store |= self.prev_next as u16;
+
+               if self.store & 0xff == 0x17 {
+                if self.prev_next == 0x0b {
+                    return Ok(Direction::Clockwise)
+                } else if self.prev_next == 0x07 {
+                    return Ok(Direction::CounterClockwise)
+                }
+               }
+           },
+           _ => return Ok(Direction::None)
+        }
+
+        Ok(Direction::None)
     } 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ where
             state: 0u8,
         }
     }
+
+    #[cfg(not(feature = "table-decoder"))]
     /// Call `update` to evaluate the next state of the encoder, propagates errors from `InputPin` read
     pub fn update(&mut self) -> Result<Direction, Either<A::Error, B::Error>> {
         // use mask to get previous state value
@@ -73,4 +75,9 @@ where
         self.state = s >> 2;
         Ok(s.into())
     }
+
+
+    #[cfg(feature = "table-decoder")]
+    pub fn update(&mut self) -> Result<Direction, Either<A::Error, B::Error>> {
+    } 
 }


### PR DESCRIPTION
I had some trouble getting reliable results with a noisy mechanical rotary decoder, so I started reading into this issue and finally found https://www.best-microcontroller-projects.com/rotary-encoder.html which showed how table based decoding can be used to get more reliability on noisy encoders.
The C version seems to work fine, this rust port needs real world testing though.
With this PR I would like to check if this change within the intended scope of the library and if such changes are welcome. 