### PR TITLE
Derive `defmt::Format` for all types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ readme = "README.md"
 embedded-hal = { version = "0.2", features = ["unproven"] }
 either = { version = "1.6", default-features = false }
 
+[dependencies.defmt]
+version  = "0.1.2"
+optional = true
+
 [dev-dependencies]
 version-sync = "0.9"
 cortex-m = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use hal::digital::v2::InputPin;
 
 /// Holds current/old state and both [`InputPin`](https://docs.rs/embedded-hal/0.2.3/embedded_hal/digital/v2/trait.InputPin.html)
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Rotary<A, B> {
     pin_a: A,
     pin_b: B,
@@ -30,6 +31,7 @@ pub struct Rotary<A, B> {
 
 /// The encoder direction is either `Clockwise`, `CounterClockwise`, or `None`
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Direction {
     /// A clockwise turn
     Clockwise,


### PR DESCRIPTION
Hide this (and the dependency on defmt that it requires) behind a Cargo
feature, as to not add any additional overhead for those who don't need
it.