### PR TITLE
table-decoder: Correct high/low mismatch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,9 @@ where
     /// Call `update` to evaluate the next state of the encoder, propagates errors from `InputPin` read
     pub fn update(&mut self) -> Result<Direction, Either<A::Error, B::Error>> {
         #[cfg(not(feature = "embedded-hal-alpha"))]
-        let (a_is_high, b_is_high) = (self.pin_a.is_high(), self.pin_b.is_low());
+        let (a_is_high, b_is_high) = (self.pin_a.is_high(), self.pin_b.is_high());
         #[cfg(feature = "embedded-hal-alpha")]
-        let (a_is_high, b_is_high) = (self.pin_a.is_high(), self.pin_b.is_low());
+        let (a_is_high, b_is_high) = (self.pin_a.is_high(), self.pin_b.is_high());
 
         // Implemented after https://www.best-microcontroller-projects.com/rotary-encoder.html
         self.prev_next <<= 2;


### PR DESCRIPTION
b_is_high was actually set to whether the b is low; Which seemed to
mostly work apart from when doing one step CW followed by one CCW.
Correct this to compare high states of both inputs