### PR TITLE
Add method to get mutable reference to both pins in one go

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,11 @@ where
         &mut self.pin_b
     }
 
+    /// Returns a reference to both pins. Can be used to clear interrupt.
+    pub fn pins(&mut self) -> (&mut A, &mut B) {
+        (&mut self.pin_a, &mut self.pin_b)
+    }
+
     /// Consumes this `Rotary`, returning the underlying pins `A` and `B`.
     pub fn into_inner(self) -> (A, B) {
         (self.pin_a, self.pin_b)


### PR DESCRIPTION
Only being able to get one pin at a time can be limiting at times; In
particular when you want to wait for the next edge, you'll need them
both at the same time.