### PR TITLE
Compatible with embedded_hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/leshow/rotary-encoder-hal"
 
 [dependencies]
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "1.0.0"}
 either = { version = "1.6", default-features = false }
 
 [dependencies.defmt]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A simple, platform agnostic rotary encoder library.
 
 An alternate decoder algorithm that is more tolerant of
-noise is enabled by the Cargo feature `table-encoder`.  It
+noise is enabled by the Cargo feature `table-decoder`.  It
 follows the discussion of noisy decoding
 [here](https://www.best-microcontroller-projects.com/rotary-encoder.html).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 use either::Either;
 
 #[cfg(not(feature = "embedded-hal-alpha"))]
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 #[cfg(feature = "embedded-hal-alpha")]
 use embedded_hal_alpha::digital::blocking::InputPin;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use rotary_encoder_hal::{Direction, Rotary};
 
 #[cfg(not(feature = "embedded-hal-alpha"))]
-use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::InputPin;
 
 #[cfg(feature = "embedded-hal-alpha")]
 use embedded_hal_alpha::digital::blocking::InputPin;


### PR DESCRIPTION
Changed InputPin import and embedded_hal versions to work with 1.0.0